### PR TITLE
Potential fix for code scanning alert no. 41: Shell command built from environment values

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -173,12 +173,12 @@ const common = {
   switchReactDevelopmentMode (cb) {
     const reactFrom = path.join(outputPath, 'js', 'react.development.js')
     const reactTo = path.join(outputPath, 'js', 'react.production.min.js')
-    cp.execSync(`mv ${reactFrom} ${reactTo}`, { stdio: 'inherit' })
+    cp.execFileSync('mv', [reactFrom, reactTo], { stdio: 'inherit' })
 
     const reactDomFrom = path.join(outputPath, 'js', 'react-dom.development.js')
     const reactDomTo = path.join(outputPath, 'js',
       'react-dom.production.min.js')
-    cp.execSync(`mv ${reactDomFrom} ${reactDomTo}`, { stdio: 'inherit' })
+    cp.execFileSync('mv', [reactDomFrom, reactDomTo], { stdio: 'inherit' })
 
     cb()
   },


### PR DESCRIPTION
Potential fix for [https://github.com/lhewett946/logseq/security/code-scanning/41](https://github.com/lhewett946/logseq/security/code-scanning/41)

To fix the issue, the shell command should be refactored to use `cp.execFileSync` instead of `cp.execSync`. This allows the command and its arguments to be passed separately, avoiding shell interpretation of the paths. Specifically:
1. Replace the `mv` command string with the command name (`mv`) and pass the source and destination paths as arguments.
2. Ensure no functionality changes occur, and the paths are still correctly moved.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
